### PR TITLE
Add service_ingress variable to control restricted network access

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,41 +17,67 @@ module cloud_run {
 }
 ```
 
+## Requirements
+
+| Name | Version |
+|------|---------|
+| terraform | >= 0.12 |
+
+## Providers
+
+| Name | Version |
+|------|---------|
+| google | n/a |
+
+## Modules
+
+No Modules.
+
+## Resources
+
+| Name |
+|------|
+| [google_cloud_run_domain_mapping](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/cloud_run_domain_mapping) |
+| [google_cloud_run_service](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/cloud_run_service) |
+| [google_cloud_run_service_iam_member](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/cloud_run_service_iam_member) |
+| [google_project](https://registry.terraform.io/providers/hashicorp/google/latest/docs/data-sources/project) |
+
 ## Inputs
 
-| Name                  | Description                                                                                    | Type         | Default                 | Required |
-|-----------------------|------------------------------------------------------------------------------------------------|--------------|-------------------------|----------|
-| name                  | Name of the Cloud Run service.                                                                 | string       |                         | Yes      |
-| image                 | GCR-hosted image to deploy to the service.                                                     | string       |                         | Yes      |
-| location              | Location in which to run the service.                                                          | string       |                         | Yes      |
-| allow_public_access   | Allow non-authenticated access to the service.                                                 | bool         | `true`                  | No       |
-| cloudsql_connections  | Cloud SQL connections to attach to service instances.                                          | list(string) | `[]`                    | No       |
-| concurrency           | Maximum number of requests a single service instance can handle at once.                       | number       | `null`                  | No       |
-| cpus                  | CPUs to allocate to service instances.                                                         | number       | `1`                     | No       |
-| env                   | Environment variables to inject into the service instance.                                     | map(string)  | `{}`                    | No       |
-| labels                | Map of [labels](https://cloud.google.com/run/docs/configuring/labels) to apply to the service. | map(string)  | `{}`                    | No       |
-| map_domains           | Domain names to map to this service instance.                                                  | set(string)  | `[]`                    | No       |
-| max_instances         | Maximum number of service instances to allow to start.                                         | number       | `1000`                  | No       |
-| memory                | Memory (in MB) to allocate to service instances.                                               | number       | `256`                   | No       |
-| min_instances         | Minimum number of service instances to keep running.                                           | number       | `0`                     | No       |
-| port                  | Port on which the container is listening for incoming HTTP requests.                           | number       | `8080`                  | No       |
-| project               | Google Cloud project in which to create the service.                                           | string       | `null`                  | No       |
-| revision              | Revision name to create and deploy. When `null`, revision names are automatically generated.   | string       | `null`                  | No       |
-| service_account_email | Service account email to assign to the service.                                                | string       | `null`                  | No       |
-| timeout               | Length of time (in seconds) to allow requests to run for.                                      | number       | `60`                    | No       |
-| vpc_access_egress     | Specify whether to divert all outbound traffic through a VPC, or private ranges only.          | string       | `"private-ranges-only"` | No       |
-| vpc_connector_name    | VPC connector to apply to this service.                                                        | string       | `null`                  | No       |
+| Name | Description | Type | Default | Required |
+|------|-------------|------|---------|:--------:|
+| allow\_public\_access | Allow non-authenticated access to the service. | `bool` | `true` | no |
+| cloudsql\_connections | Cloud SQL connections to attach to service instances. | `list(string)` | `[]` | no |
+| concurrency | Maximum number of requests a single service instance can handle at once. | `number` | `null` | no |
+| cpus | CPUs to allocate to service instances. | `number` | `1` | no |
+| env | Environment variables to inject into the service instance. | `map(string)` | `{}` | no |
+| image | GCR-hosted image to deploy to the service. | `string` | n/a | yes |
+| labels | Labels to apply to the service. | `map(string)` | `{}` | no |
+| location | Location in which to run the service. | `string` | n/a | yes |
+| map\_domains | Domain names to map to this service instance. | `set(string)` | `[]` | no |
+| max\_instances | Maximum number of service instances to allow to start. | `number` | `1000` | no |
+| memory | Memory (in MB) to allocate to service instances. | `number` | `256` | no |
+| min\_instances | Minimum number of service instances to keep running. | `number` | `0` | no |
+| name | Name of the Cloud Run service. | `string` | n/a | yes |
+| port | Port on which the container is listening for incoming HTTP requests. | `number` | `8080` | no |
+| project | Google Cloud project in which to create the service. | `string` | `null` | no |
+| revision | Revision name to create and deploy. | `string` | `null` | no |
+| service\_account\_email | Service account email to assign to the service. | `string` | `null` | no |
+| service\_ingress | Use ingress settings to restrict network access to this service. Available ingress settings: `all`, `internal` or `internal-and-cloud-load-balancing`. | `string` | `"all"` | no |
+| timeout | Length of time (in seconds) to allow requests to run for. | `number` | `60` | no |
+| vpc\_access\_egress | Specify whether to divert all outbound traffic through the VPC, or private ranges only. | `string` | `"private-ranges-only"` | no |
+| vpc\_connector\_name | VPC connector to apply to this service. | `string` | `null` | no |
 
 ## Outputs
 
-| Name     | Description                                                                       | Type                                                                  |
-|----------|-----------------------------------------------------------------------------------|-----------------------------------------------------------------------|
-| dns      | DNS records to populate for mapped domains. Keys are the domains that are mapped. | map(object({ type = string, name = string, rrdatas = list(string) })) |
-| labels   | Labels applied to the created service.                                            | map(string)                                                           |
-| name     | Name of the created service.                                                      | string                                                                |
-| project  | Google Cloud project in which the service was created.                            | string                                                                |
-| revision | Deployed revision for the service.                                                | string                                                                |
-| url      | The URL on which the deployed service is available.                               | string                                                                |
+| Name | Description |
+|------|-------------|
+| dns | DNS records to populate for mapped domains. Keys are the domains that are mapped. |
+| labels | Labels applied to the created service. |
+| name | Name of the created service. |
+| project | Google Cloud project in which the service was created. |
+| revision | Deployed revision for the service. |
+| url | The URL on which the deployed service is available. |
 
 ## Changelog
 

--- a/locals.tf
+++ b/locals.tf
@@ -1,3 +1,0 @@
-locals {
-  service_ingress = "all"
-}

--- a/outputs.tf
+++ b/outputs.tf
@@ -1,59 +1,59 @@
 output name {
-  value = google_cloud_run_service.default.name
+  value       = google_cloud_run_service.default.name
   description = "Name of the created service."
 }
 
 output revision {
-  value = google_cloud_run_service.default.status[0].latest_ready_revision_name
+  value       = google_cloud_run_service.default.status[0].latest_ready_revision_name
   description = "Deployed revision for the service."
 }
 
 output url {
-  value = google_cloud_run_service.default.status[0].url
+  value       = google_cloud_run_service.default.status[0].url
   description = "The URL on which the deployed service is available."
 }
 
 output project {
-  value = google_cloud_run_service.default.project
+  value       = google_cloud_run_service.default.project
   description = "Google Cloud project in which the service was created."
 }
 
 output labels {
-  value = google_cloud_run_service.default.metadata[0].labels
+  value       = google_cloud_run_service.default.metadata[0].labels
   description = "Labels applied to the created service."
 }
 
 locals {
   output_dns_pairs = {
-    for domain in var.map_domains:
-      domain => distinct([
-        for record in google_cloud_run_domain_mapping.domains[domain].status[0].resource_records:
-          "${record.type}/${record.name}"
-      ])
+    for domain in var.map_domains :
+    domain => distinct([
+      for record in google_cloud_run_domain_mapping.domains[domain].status[0].resource_records :
+      "${record.type}/${record.name}"
+    ])
   }
   output_dns_rrdata_by_pairs = {
-    for domain in var.map_domains:
-      domain => {
-        for pair in local.output_dns_pairs[domain]:
-          pair => [
-            for record in google_cloud_run_domain_mapping.domains[domain].status[0].resource_records:
-              record.rrdata
-            if "${record.type}/${record.name}" == pair
-          ]
-      }
+    for domain in var.map_domains :
+    domain => {
+      for pair in local.output_dns_pairs[domain] :
+      pair => [
+        for record in google_cloud_run_domain_mapping.domains[domain].status[0].resource_records :
+        record.rrdata
+        if "${record.type}/${record.name}" == pair
+      ]
+    }
   }
 }
 
 output dns {
   value = {
-    for domain in var.map_domains:
-      domain => [
-        for pair, rrdatas in local.output_dns_rrdata_by_pairs[domain]: {
-          type = split("/", pair)[0],
-          name = split("/", pair)[1] == "" ? null : split("/", pair)[1],
-          rrdatas = rrdatas
-        }
-      ]
+    for domain in var.map_domains :
+    domain => [
+      for pair, rrdatas in local.output_dns_rrdata_by_pairs[domain] : {
+        type    = split("/", pair)[0],
+        name    = split("/", pair)[1] == "" ? null : split("/", pair)[1],
+        rrdatas = rrdatas
+      }
+    ]
   }
   description = "DNS records to populate for mapped domains. Keys are the domains that are mapped."
 }

--- a/variables.tf
+++ b/variables.tf
@@ -1,116 +1,122 @@
 variable name {
-  type = string
+  type        = string
   description = "Name of the Cloud Run service."
 }
 
 variable image {
-  type = string
+  type        = string
   description = "GCR-hosted image to deploy to the service."
 }
 
 variable location {
-  type = string
+  type        = string
   description = "Location in which to run the service."
 }
 
 variable labels {
-  type = map(string)
-  default = {}
+  type        = map(string)
+  default     = {}
   description = "Labels to apply to the service."
 }
 
 variable allow_public_access {
-  type = bool
-  default = true
+  type        = bool
+  default     = true
   description = "Allow non-authenticated access to the service."
 }
 
 variable memory {
-  type = number
-  default = 256
+  type        = number
+  default     = 256
   description = "Memory (in MB) to allocate to service instances."
 }
 
 variable project {
-  type = string
-  default = null
+  type        = string
+  default     = null
   description = "Google Cloud project in which to create the service."
 }
 
 variable cpus {
-  type = number
-  default = 1
+  type        = number
+  default     = 1
   description = "CPUs to allocate to service instances."
 }
 
 variable cloudsql_connections {
-  type = list(string)
-  default = []
+  type        = list(string)
+  default     = []
   description = "Cloud SQL connections to attach to service instances."
 }
 
 variable revision {
-  type = string
-  default = null
+  type        = string
+  default     = null
   description = "Revision name to create and deploy."
 }
 
 variable timeout {
-  type = number
-  default = 60
+  type        = number
+  default     = 60
   description = "Length of time (in seconds) to allow requests to run for."
 }
 
 variable concurrency {
-  type = number
-  default = null
+  type        = number
+  default     = null
   description = "Maximum number of requests a single service instance can handle at once."
 }
 
 variable max_instances {
-  type = number
-  default = 1000
+  type        = number
+  default     = 1000
   description = "Maximum number of service instances to allow to start."
 }
 
 variable min_instances {
-  type = number
-  default = 0
+  type        = number
+  default     = 0
   description = "Minimum number of service instances to keep running."
 }
 
 variable service_account_email {
-  type = string
-  default = null
+  type        = string
+  default     = null
   description = "Service account email to assign to the service."
 }
 
 variable map_domains {
-  type = set(string)
-  default = []
+  type        = set(string)
+  default     = []
   description = "Domain names to map to this service instance."
 }
 
 variable env {
-  type = map(string)
-  default = {}
+  type        = map(string)
+  default     = {}
   description = "Environment variables to inject into the service instance."
 }
 
 variable vpc_connector_name {
-  type = string
-  default = null
+  type        = string
+  default     = null
   description = "VPC connector to apply to this service."
 }
 
 variable vpc_access_egress {
-  type = string
-  default = "private-ranges-only"
+  type        = string
+  default     = "private-ranges-only"
   description = "Specify whether to divert all outbound traffic through the VPC, or private ranges only."
 }
 
 variable port {
-  type = number
-  default = 8080
+  type        = number
+  default     = 8080
   description = "Port on which the container is listening for incoming HTTP requests."
+}
+
+variable service_ingress {
+  type        = string
+  default     = "all"
+  description = "Use ingress settings to restrict network access to this service. Available ingress settings: `all`, `internal` or `internal-and-cloud-load-balancing`."
 }


### PR DESCRIPTION
Replacing `local.service_ingress` for a variable to allow Cloud Run service ingress to be controlled. The variable's default value remains `all`, so there's no change in this module's functionality unless the variable is set to a different value.

I've not included any custom validation rules for the variable to allow the module to continue supporting Terraform v0.12 (custom validation rules for variables is a Terraform v0.13 feature).

The white space changes introduced by using [`terraform fmt`](https://www.terraform.io/docs/cli/commands/fmt.html) to rewrite files to Terraform's canonical format and style.

I retained the missing `"` style for consistency even though it doesn't match the [Terraform style conventions](https://www.terraform.io/docs/language/syntax/style.html).

Readme updated using [`terraform-docs`](https://github.com/terraform-docs/terraform-docs).