### PR TITLE
Adding CPU throttling flag

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -120,6 +120,7 @@ resource google_cloud_run_service default {
       annotations = merge(
         {
           "run.googleapis.com/launch-stage" = local.launch_stage
+          "run.googleapis.com/cpu-throttling" = var.cpu_throttling
           "run.googleapis.com/cloudsql-instances" = join(",", var.cloudsql_connections)
           "autoscaling.knative.dev/maxScale" = var.max_instances
           "autoscaling.knative.dev/minScale" = var.min_instances

--- a/variables.tf
+++ b/variables.tf
@@ -45,6 +45,12 @@ variable cpus {
   description = "Number of CPUs to allocate per container."
 }
 
+variable cpu_throttling {
+  type = bool
+  default = true
+  description = "CPU is only allocated during request processing"
+}
+
 variable entrypoint {
   type = list(string)
   default = []


### PR DESCRIPTION
Google has introduced CPU throttling configuration and it would be better to support it in the `module` as well

https://cloud.google.com/blog/products/serverless/cloud-run-gets-always-on-cpu-allocation