### PR TITLE
BETA is still required for Secret Manager

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -120,7 +120,6 @@ resource google_cloud_run_service default {
       labels = var.labels
       annotations = merge(
         {
-          "run.googleapis.com/launch-stage" = local.launch_stage
           "run.googleapis.com/cpu-throttling" = var.cpu_throttling
           "run.googleapis.com/cloudsql-instances" = join(",", var.cloudsql_connections)
           "autoscaling.knative.dev/maxScale" = var.max_instances


### PR DESCRIPTION
BETA annotation is still required in order to use Secret Manager

It was working fine with your `terraform` module version 2.0.0 then I've seen this line 

[2.0.0...2.1.0](https://github.com/garbetjie/terraform-google-cloud-run/compare/2.0.0...2.1.0#diff-dc46acf24afd63ef8c556b77c126ccc6e578bc87e3aa09a931f33d9bf2532fbbL15)

We should keep it for Secret Manager integration otherwise we will get this error
```
│ Details:
│ [
│   {
│     "@type": "type.googleapis.com/google.rpc.BadRequest",
│     "fieldViolations": [
│       {
│         "description": "spec.template.spec.containers[0].env.valueFrom should be empty",
│         "field": "spec.template.spec.containers[0].env.valueFrom"
│       }
│     ]
│   }
│ ]
```

more information can be found [here](https://github.com/hashicorp/terraform-provider-google/issues/9159#issuecomment-852202135)