### PR TITLE
feat: add Cloud Run API dependency

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -141,6 +141,10 @@ resource google_cloud_run_service default {
     latest_revision = var.revision == null
     revision_name = var.revision != null ? "${var.name}-${var.revision}" : null
   }
+
+  depends_on = [
+    google_project_service.run_api
+  ]
 }
 
 

--- a/services.tf
+++ b/services.tf
@@ -1,0 +1,4 @@
+resource "google_project_service" "run_api" {
+  service            = "run.googleapis.com"
+  disable_on_destroy = true
+}

--- a/services.tf
+++ b/services.tf
@@ -1,4 +1,4 @@
-resource "google_project_service" "run_api" {
-  service            = "run.googleapis.com"
+resource google_project_service run_api {
+  service = "run.googleapis.com"
   disable_on_destroy = true
 }


### PR DESCRIPTION
Added a dependency on the Cloud Run API. This will enable it on apply if not enabled already, and disable it again on destroy.
