### PR TITLE
Launch stage annotation triggers update in place

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -32,6 +32,7 @@ resource google_cloud_run_service default {
       metadata[0].annotations["serving.knative.dev/creator"],
       metadata[0].annotations["serving.knative.dev/lastModifier"],
       metadata[0].annotations["run.googleapis.com/ingress-status"],
+      metadata[0].annotations["run.googleapis.com/launch-stage"],
       metadata[0].labels["cloud.googleapis.com/location"],
     ]
   }


### PR DESCRIPTION
I've noticed that after a Cloud Run service gets deployed sometimes the `run.googleapis.com/launch-stage` annotation is removed from the service (presumably by Cloud Run), and then when re-running this module it will require an update in place:

```
  # module.some-service.module.cloud_run.google_cloud_run_service.default will be updated in-place
  ~ resource "google_cloud_run_service" "default" {
        id                         = "locations/us-central1/namespaces/some-project/services/some-service"
        name                       = "some-service"
        # (4 unchanged attributes hidden)
      ~ metadata {
          ~ annotations      = {
              + "run.googleapis.com/launch-stage"   = "BETA"
                # (7 unchanged elements hidden)
            }
            # (6 unchanged attributes hidden)
        }
        # (2 unchanged blocks hidden)
    }
```

I added the annotation to the `ignore_changes` fields to get around it, however not totally sure that's the best option given you are explicitly setting it.