### PR TITLE
fix: wait for Cloud Run instance to be created

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -152,6 +152,9 @@ resource google_cloud_run_service_iam_member public_access {
   project = google_cloud_run_service.default.project
   role = "roles/run.invoker"
   member = "allUsers"
+  depends_on = [
+    google_cloud_run_service.default
+  ]
 }
 
 resource google_cloud_run_domain_mapping domains {
@@ -175,4 +178,8 @@ resource google_cloud_run_domain_mapping domains {
   lifecycle {
     ignore_changes = [metadata[0]]
   }
+  
+  depends_on = [
+    google_cloud_run_service.default
+  ]
 }


### PR DESCRIPTION
This ensures the Run instance is created fist. Sometimes, GCP throws an error when trying to create a IAM policy or domain mapping for an instance that does not exist (yet).