### PR TITLE
fix: Remove `module_variable_optional_attrs` experiment

### DIFF
--- a/providers.tf
+++ b/providers.tf
@@ -1,6 +1,5 @@
 terraform {
-  experiments = [module_variable_optional_attrs]
-  required_version = ">= 0.14"
+  required_version = ">= 1.3"
 
   required_providers {
     google = {


### PR DESCRIPTION
The experiment `module_variable_optional_attrs` has ended and version 1.3 of Terraform will not permit a configuration to contain reference to the experiment, thus, this module is not working in 1.3.

> Because the experiment is concluded, the experimental implementation of this feature is no longer available and Terraform v1.3.0 and later will not accept any module that contains the explicit experiment opt-in.

https://www.terraform.io/language/upgrade-guides#concluding-the-optional-attributes-experiment

I have removed `module_variable_optional_attrs` from `providers.tf` and changed the minimum version to 1.3. I think this bump in version (from 0.14 -> 1.3) qualifies as a breaking change, so this should be released as v3 of the module.

As a short term workaround for anyone encountering this issue, limit your version of Terraform to 1.2:

```hcl
terraform {
  required_version = "~> 1.2.0"

  experiments = [module_variable_optional_attrs]
}
```